### PR TITLE
Remove private arglist argument from test function

### DIFF
--- a/stylesheets/main.scss
+++ b/stylesheets/main.scss
@@ -11,7 +11,7 @@
 ///   * `pass`: number of passing tests out of `length`
 ///   * `fail`: number of failing tests out of `length`
 ///   * `tests`: list of maps containing:
-///       * `input`: test input (key from `$tests`) 
+///       * `input`: test input (key from `$tests`)
 ///       * `expected`: expected result from `input`
 ///       * `actual`: actual result from `input`
 ///       * `pass`: whether the test passed or not
@@ -52,7 +52,7 @@
   $tests: ();
 
   @each $test, $expected-result in $test-suite {
-    $result: call($function, $test...);
+    $result: call($function, $test);
     $tests: append($tests, (
       'input': $test,
       'expected': $expected-result,
@@ -65,7 +65,7 @@
       $passing-tests: $passing-tests + 1;
     }
   }
-  
+
   @return (
     'function': $function,
     'length': length($tests),
@@ -76,7 +76,7 @@
 }
 
 /// Mixin decorating the result of `test(..)` function to throw it as an error
-/// 
+///
 /// @author Hugo Giraudel
 ///
 /// @param {Map} $data - Return of `test(..)` function
@@ -97,13 +97,13 @@
   $output: '';
   $length: map-get($data, 'length');
   $tests: map-get($data, 'tests');
-  
+
   @each $test in $tests {
-    $output: $output 
+    $output: $output
       + 'Test #{index($tests, $test)} out of #{$length}... '
       + if(map-get($test, 'pass'), '✔', '✘\a   Expected : `#{map-get($test, "expected")}`\a   Actual   : `#{map-get($test, "actual")}`') + '\a ';
   }
-  
+
   @error 'Started tests for function `#{map-get($data, "function")}`\a '
     + '----------\a '
     + $output + '\a '


### PR DESCRIPTION
I have removed `arglist` from the `@each` loop in `test` function, it will let us use `maps` and `lists` as function inputs. 

[input map error](http://take.ms/C7DV2)

[input list error](http://take.ms/y1QUs)
