### PR TITLE
Throw error when a test is not passing

### DIFF
--- a/sass/_SassyTester.scss
+++ b/sass/_SassyTester.scss
@@ -106,9 +106,15 @@
       + if(map-get($test, 'pass'), '✔', '✘\a   Expected : `#{map-get($test, "expected")}`\a   Actual   : `#{map-get($test, "actual")}`') + '\a ';
   }
 
-  @warn 'Started tests for function `#{map-get($data, "function")}`\a '
+  $message: 'Started tests for function `#{map-get($data, "function")}`\a '
     + '----------\a '
     + $output + '\a '
     + '----------\a '
     + 'Finished: #{map-get($data, "fail")} test(s) failing out of #{$length}';
+
+  @if map-get($data, "fail") > 0 {
+    @error $message;
+  } @else {
+    @warn $message;
+  }
 }


### PR DESCRIPTION
In order to identify quickly which test is not passing. And, on CI, make sure when a test is not good the engine says so.
